### PR TITLE
Fix：鼠标更新Camera锁定帧数

### DIFF
--- a/src/classes/camera.ts
+++ b/src/classes/camera.ts
@@ -2,6 +2,11 @@ import { mat4, vec3 } from 'gl-matrix'
 import { basicData, globalInfo, globalProp } from '../initial/globalProp'
 import { getX, getY, vectorAngle } from '../utils'
 import { QuadTree } from '../utils/quadTree'
+import { throttle } from 'lodash'
+
+const Throttle = throttle((events, viewChange) => {
+    events.emit('camerarefresh', viewChange)
+}, 16)
 
 class Camera {
     public gl: WebGLRenderingContext
@@ -251,10 +256,7 @@ class Camera {
     updateCameraVectors(viewChange: boolean = false) {
         this.cameraChange = true
         this.ratio = 2 * (this.position[2] * Math.tan((this.zoom * Math.PI) / 360))
-        // Event.trigger('camerarefresh', viewChange)
-        this.events.emit('camerarefresh', 
-            viewChange
-        )
+        Throttle(this.events, viewChange)
     }
 }
 

--- a/src/classes/camera.ts
+++ b/src/classes/camera.ts
@@ -4,8 +4,8 @@ import { getX, getY, vectorAngle } from '../utils'
 import { QuadTree } from '../utils/quadTree'
 import { throttle } from 'lodash'
 
-const Throttle = throttle((events, viewChange) => {
-    events.emit('camerarefresh', viewChange)
+const Throttle = throttle((events, viewChange, refesh = false) => {
+    events.emit('camerarefresh', viewChange, refesh)
 }, 16)
 
 class Camera {
@@ -224,10 +224,7 @@ class Camera {
                         })
                     }
                 })
-                // Event.trigger('camerarefresh', false, true)
-                this.events.emit('camerarefresh', 
-                    false, true
-                )
+                Throttle(this.events, false, true)
             }
             this.startMouseX = pointX
             this.startMouseY = pointY


### PR DESCRIPTION
原先的Camera更新太过频繁，现在加了throttle(( )=>{ }, 16 )